### PR TITLE
Retrofit DI

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,10 +18,6 @@ android {
 
 dependencies {
     implementation project(':auth')
-    implementation project(':auth-usecase')
-    implementation project(':auth-infra')
-    implementation project(':auth-domain')
-
     implementation project(':project')
 
     // retrofit

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,5 +18,15 @@ android {
 
 dependencies {
     implementation project(':auth')
+    implementation project(':auth-usecase')
+    implementation project(':auth-infra')
+    implementation project(':auth-domain')
+
     implementation project(':project')
+
+    // retrofit
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
+    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
+    implementation "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:$coroutines_adapter_version"
+    implementation "com.google.code.gson:gson:$gson_version"
 }

--- a/app/src/main/java/lu/aqu/projper/Projper.kt
+++ b/app/src/main/java/lu/aqu/projper/Projper.kt
@@ -3,9 +3,9 @@ package lu.aqu.projper
 import android.app.Application
 import lu.aqu.core.di.ComponentHolder
 import lu.aqu.core.di.Injector
-import lu.aqu.projper.auth.AuthModule
 import lu.aqu.projper.auth.login.di.DaggerLoginComponent
 import lu.aqu.projper.auth.login.di.LoginComponent
+import lu.aqu.projper.di.DaggerProjperComponent
 import lu.aqu.projper.project.details.di.DaggerDetailsComponent
 import lu.aqu.projper.project.details.di.DetailsComponent
 import lu.aqu.projper.project.overview.di.DaggerOverviewComponent
@@ -18,10 +18,19 @@ class Projper : Application(), ComponentHolder {
 
     override fun onCreate() {
         super.onCreate()
+
+        val coreComponent = DaggerProjperComponent.builder().application(this).build()
+
         components = mapOf(
-            OverviewComponent::class to DaggerOverviewComponent.create(),
-            DetailsComponent::class to DaggerDetailsComponent.create(),
-            LoginComponent::class to DaggerLoginComponent.builder().authModule(AuthModule(this)).build()
+            OverviewComponent::class to DaggerOverviewComponent.builder()
+                .retrofit(coreComponent.retrofit())
+                .build(),
+            DetailsComponent::class to DaggerDetailsComponent.builder()
+                .retrofit(coreComponent.retrofit())
+                .build(),
+            LoginComponent::class to DaggerLoginComponent.builder()
+                .sharedPreferences(coreComponent.sharedPreferences())
+                .build()
         )
     }
 

--- a/app/src/main/java/lu/aqu/projper/Projper.kt
+++ b/app/src/main/java/lu/aqu/projper/Projper.kt
@@ -3,9 +3,11 @@ package lu.aqu.projper
 import android.app.Application
 import lu.aqu.core.di.ComponentHolder
 import lu.aqu.core.di.Injector
+import lu.aqu.projper.auth.hostservice.DaggerAccessTokenServiceComponent
 import lu.aqu.projper.auth.login.di.DaggerLoginComponent
 import lu.aqu.projper.auth.login.di.LoginComponent
-import lu.aqu.projper.di.DaggerProjperComponent
+import lu.aqu.projper.di.DaggerRetrofitComponent
+import lu.aqu.projper.di.DaggerSharedPreferencesComponent
 import lu.aqu.projper.project.details.di.DaggerDetailsComponent
 import lu.aqu.projper.project.details.di.DetailsComponent
 import lu.aqu.projper.project.overview.di.DaggerOverviewComponent
@@ -19,17 +21,28 @@ class Projper : Application(), ComponentHolder {
     override fun onCreate() {
         super.onCreate()
 
-        val coreComponent = DaggerProjperComponent.builder().application(this).build()
+        val sharedPreferencesComponent = DaggerSharedPreferencesComponent
+            .builder()
+            .application(this)
+            .build()
+
+        val accessTokenServiceComponent = DaggerAccessTokenServiceComponent.builder()
+            .sharedPreferences(sharedPreferencesComponent.sharedPreferences())
+            .build()
+
+        val retrofitComponent = DaggerRetrofitComponent.builder()
+            .accessTokenService(accessTokenServiceComponent.accessTokenService())
+            .build()
 
         components = mapOf(
             OverviewComponent::class to DaggerOverviewComponent.builder()
-                .retrofit(coreComponent.retrofit())
+                .retrofit(retrofitComponent.retrofit())
                 .build(),
             DetailsComponent::class to DaggerDetailsComponent.builder()
-                .retrofit(coreComponent.retrofit())
+                .retrofit(retrofitComponent.retrofit())
                 .build(),
             LoginComponent::class to DaggerLoginComponent.builder()
-                .sharedPreferences(coreComponent.sharedPreferences())
+                .sharedPreferences(sharedPreferencesComponent.sharedPreferences())
                 .build()
         )
     }

--- a/app/src/main/java/lu/aqu/projper/di/ApiModule.kt
+++ b/app/src/main/java/lu/aqu/projper/di/ApiModule.kt
@@ -1,0 +1,52 @@
+package lu.aqu.projper.di
+
+import com.google.gson.Gson
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import dagger.Module
+import dagger.Provides
+import lu.aqu.core.util.Constants
+import lu.aqu.projper.auth.hostservice.AccessTokenModule
+import lu.aqu.projper.auth.hostservice.AccessTokenService
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+@Module(includes = [AccessTokenModule::class])
+internal class ApiModule {
+
+    @Provides
+    fun provideAuthInterceptor(accessTokenService: AccessTokenService): Interceptor =
+        Interceptor { chain ->
+            val accessToken = accessTokenService.getAccessToken()
+
+            val request = chain.request()
+                .newBuilder()
+                .apply {
+                    if (accessToken != null) {
+                        addHeader(Constants.Api.AUTH_HEADER, "Bearer $accessToken")
+                    }
+                }
+                .build()
+
+            chain.proceed(request)
+        }
+
+    @Provides
+    fun provideGson(): Gson = Gson()
+
+    @Provides
+    fun provideOkHttpClient(interceptor: Interceptor): OkHttpClient =
+        OkHttpClient.Builder()
+            .addInterceptor(interceptor)
+            .build()
+
+    @Provides
+    fun provideRetrofit(okHttpClient: OkHttpClient, gson: Gson): Retrofit =
+        Retrofit.Builder()
+            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+            .baseUrl(Constants.Api.BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .build()
+}

--- a/app/src/main/java/lu/aqu/projper/di/ApiModule.kt
+++ b/app/src/main/java/lu/aqu/projper/di/ApiModule.kt
@@ -5,14 +5,13 @@ import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterF
 import dagger.Module
 import dagger.Provides
 import lu.aqu.core.util.Constants
-import lu.aqu.projper.auth.hostservice.AccessTokenModule
 import lu.aqu.projper.auth.hostservice.AccessTokenService
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
-@Module(includes = [AccessTokenModule::class])
+@Module
 internal class ApiModule {
 
     @Provides

--- a/app/src/main/java/lu/aqu/projper/di/ProjperComponent.kt
+++ b/app/src/main/java/lu/aqu/projper/di/ProjperComponent.kt
@@ -1,0 +1,29 @@
+package lu.aqu.projper.di
+
+import android.app.Application
+import android.content.SharedPreferences
+import dagger.BindsInstance
+import dagger.Component
+import retrofit2.Retrofit
+
+@Component(
+    modules = [
+        ApiModule::class,
+        SharedPreferencesModule::class
+    ]
+)
+interface ProjperComponent {
+
+    fun sharedPreferences(): SharedPreferences
+
+    fun retrofit(): Retrofit
+
+    @Component.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun application(application: Application): Builder
+
+        fun build(): ProjperComponent
+    }
+}

--- a/app/src/main/java/lu/aqu/projper/di/RetrofitComponent.kt
+++ b/app/src/main/java/lu/aqu/projper/di/RetrofitComponent.kt
@@ -1,0 +1,23 @@
+package lu.aqu.projper.di
+
+import dagger.BindsInstance
+import dagger.Component
+import lu.aqu.projper.auth.hostservice.AccessTokenService
+import retrofit2.Retrofit
+
+@Component(
+    modules = [ApiModule::class]
+)
+interface RetrofitComponent {
+
+    fun retrofit(): Retrofit
+
+    @Component.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun accessTokenService(accessTokenService: AccessTokenService): Builder
+
+        fun build(): RetrofitComponent
+    }
+}

--- a/app/src/main/java/lu/aqu/projper/di/SharedPreferencesComponent.kt
+++ b/app/src/main/java/lu/aqu/projper/di/SharedPreferencesComponent.kt
@@ -4,19 +4,13 @@ import android.app.Application
 import android.content.SharedPreferences
 import dagger.BindsInstance
 import dagger.Component
-import retrofit2.Retrofit
 
 @Component(
-    modules = [
-        ApiModule::class,
-        SharedPreferencesModule::class
-    ]
+    modules = [SharedPreferencesModule::class]
 )
-interface ProjperComponent {
+interface SharedPreferencesComponent {
 
     fun sharedPreferences(): SharedPreferences
-
-    fun retrofit(): Retrofit
 
     @Component.Builder
     interface Builder {
@@ -24,6 +18,6 @@ interface ProjperComponent {
         @BindsInstance
         fun application(application: Application): Builder
 
-        fun build(): ProjperComponent
+        fun build(): SharedPreferencesComponent
     }
 }

--- a/app/src/main/java/lu/aqu/projper/di/SharedPreferencesModule.kt
+++ b/app/src/main/java/lu/aqu/projper/di/SharedPreferencesModule.kt
@@ -1,0 +1,19 @@
+package lu.aqu.projper.di
+
+import android.app.Application
+import android.content.Context
+import android.content.SharedPreferences
+import dagger.Module
+import dagger.Provides
+import lu.aqu.core.util.Constants
+
+@Module
+internal class SharedPreferencesModule {
+
+    @Provides
+    fun sharedPreferences(application: Application): SharedPreferences =
+        application.getSharedPreferences(
+            Constants.SHARED_PREFERENCES_NAME,
+            Context.MODE_PRIVATE
+        )
+}

--- a/gradle/infra.build.gradle
+++ b/gradle/infra.build.gradle
@@ -23,9 +23,6 @@ dependencies {
 
     // retrofit
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
-    implementation "com.squareup.retrofit2:converter-gson:$retrofit_version"
-    implementation "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:$coroutines_adapter_version"
-    implementation "com.google.code.gson:gson:$gson_version"
 }
 
 compileKotlin {

--- a/modules/core/src/main/java/lu/aqu/core/util/Constants.kt
+++ b/modules/core/src/main/java/lu/aqu/core/util/Constants.kt
@@ -2,4 +2,10 @@ package lu.aqu.core.util
 
 object Constants {
     const val SHARED_PREFERENCES_NAME = "projper"
+
+    object Api {
+        const val BASE_URL = "https://test.aqu.lu/"
+
+        const val AUTH_HEADER = "Authorization"
+    }
 }

--- a/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/AuthModule.kt
+++ b/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/AuthModule.kt
@@ -1,21 +1,13 @@
 package lu.aqu.projper.auth
 
-import android.content.Context
-import android.content.SharedPreferences
 import dagger.Module
-import dagger.Provides
-import lu.aqu.core.util.Constants
+import lu.aqu.projper.auth.infra.AuthInfraModule
 import lu.aqu.projper.auth.usecase.AuthUseCaseModule
 
 @Module(
-    includes = [AuthUseCaseModule::class]
+    includes = [
+        AuthUseCaseModule::class,
+        AuthInfraModule::class
+    ]
 )
-class AuthModule(private val context: Context) {
-
-    @Provides
-    fun sharedPreferences(): SharedPreferences =
-        context.applicationContext.getSharedPreferences(
-            Constants.SHARED_PREFERENCES_NAME,
-            Context.MODE_PRIVATE
-        )
-}
+class AuthModule

--- a/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/hostservice/AccessTokenModule.kt
+++ b/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/hostservice/AccessTokenModule.kt
@@ -1,0 +1,12 @@
+package lu.aqu.projper.auth.hostservice
+
+import dagger.Binds
+import dagger.Module
+import lu.aqu.projper.auth.AuthModule
+
+@Module(includes = [AuthModule::class])
+abstract class AccessTokenModule {
+
+    @Binds
+    internal abstract fun bindAccessTokenService(impl: AccessTokenServiceImpl): AccessTokenService
+}

--- a/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/hostservice/AccessTokenService.kt
+++ b/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/hostservice/AccessTokenService.kt
@@ -1,0 +1,9 @@
+package lu.aqu.projper.auth.hostservice
+
+interface AccessTokenService {
+
+    /**
+     * @return the access token of the currently logged in user
+     */
+    fun getAccessToken(): String?
+}

--- a/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/hostservice/AccessTokenServiceComponent.kt
+++ b/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/hostservice/AccessTokenServiceComponent.kt
@@ -1,0 +1,21 @@
+package lu.aqu.projper.auth.hostservice
+
+import android.content.SharedPreferences
+import dagger.BindsInstance
+import dagger.Component
+
+@Component(modules = [HostServiceModule::class])
+interface AccessTokenServiceComponent {
+
+    fun accessTokenService(): AccessTokenService
+
+    @Component.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun sharedPreferences(sharedPreferences: SharedPreferences): Builder
+
+        fun build(): AccessTokenServiceComponent
+    }
+}
+

--- a/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/hostservice/AccessTokenServiceImpl.kt
+++ b/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/hostservice/AccessTokenServiceImpl.kt
@@ -1,0 +1,12 @@
+package lu.aqu.projper.auth.hostservice
+
+import lu.aqu.projper.auth.usecase.GetAccessTokenUseCase
+import javax.inject.Inject
+
+internal class AccessTokenServiceImpl @Inject constructor(
+    private val getAccessTokenUseCase: GetAccessTokenUseCase
+) : AccessTokenService {
+
+    override fun getAccessToken(): String? =
+        getAccessTokenUseCase.invoke()
+}

--- a/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/hostservice/HostServiceModule.kt
+++ b/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/hostservice/HostServiceModule.kt
@@ -5,7 +5,7 @@ import dagger.Module
 import lu.aqu.projper.auth.AuthModule
 
 @Module(includes = [AuthModule::class])
-abstract class AccessTokenModule {
+internal abstract class HostServiceModule {
 
     @Binds
     internal abstract fun bindAccessTokenService(impl: AccessTokenServiceImpl): AccessTokenService

--- a/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/login/di/LoginComponent.kt
+++ b/modules/features/auth/auth/src/main/java/lu/aqu/projper/auth/login/di/LoginComponent.kt
@@ -1,5 +1,7 @@
 package lu.aqu.projper.auth.login.di
 
+import android.content.SharedPreferences
+import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjector
 import lu.aqu.core.di.FragmentScope
@@ -7,8 +9,16 @@ import lu.aqu.core.di.Injector
 import lu.aqu.projper.auth.AuthModule
 import lu.aqu.projper.auth.login.LoginFragment
 
-@Component(
-    modules = [AuthModule::class]
-)
+@Component(modules = [AuthModule::class])
 @FragmentScope
-interface LoginComponent : AndroidInjector<LoginFragment>, Injector
+interface LoginComponent : AndroidInjector<LoginFragment>, Injector {
+
+    @Component.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun sharedPreferences(sharedPreferences: SharedPreferences): Builder
+
+        fun build(): LoginComponent
+    }
+}

--- a/modules/features/auth/usecase/build.gradle
+++ b/modules/features/auth/usecase/build.gradle
@@ -1,9 +1,5 @@
-apply plugin: 'com.android.library'
-
-apply from: '../../../../gradle/android.config.gradle'
-apply from: '../../../../gradle/android.dependencies.gradle'
+apply from: '../../../../gradle/usecase.build.gradle'
 
 dependencies {
-    implementation project(':auth-infra')
     implementation project(':auth-domain')
 }

--- a/modules/features/auth/usecase/src/main/AndroidManifest.xml
+++ b/modules/features/auth/usecase/src/main/AndroidManifest.xml
@@ -1,1 +1,0 @@
-<manifest package="lu.aqu.projper.auth.usecase" />

--- a/modules/features/auth/usecase/src/main/java/lu/aqu/projper/auth/usecase/AuthUseCaseModule.kt
+++ b/modules/features/auth/usecase/src/main/java/lu/aqu/projper/auth/usecase/AuthUseCaseModule.kt
@@ -4,13 +4,10 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.Dispatchers
 import lu.aqu.projper.auth.domain.AuthRepository
-import lu.aqu.projper.auth.infra.AuthInfraModule
 import lu.aqu.projper.auth.usecase.impl.GetAccessTokenUseCaseImpl
 import lu.aqu.projper.auth.usecase.impl.LoginUseCaseImpl
 
-@Module(
-    includes = [AuthInfraModule::class]
-)
+@Module
 class AuthUseCaseModule {
 
     @Provides

--- a/modules/features/auth/usecase/src/main/java/lu/aqu/projper/auth/usecase/AuthUseCaseModule.kt
+++ b/modules/features/auth/usecase/src/main/java/lu/aqu/projper/auth/usecase/AuthUseCaseModule.kt
@@ -19,5 +19,5 @@ class AuthUseCaseModule {
 
     @Provides
     fun provideGetAccessTokenUseCase(authRepository: AuthRepository): GetAccessTokenUseCase =
-        GetAccessTokenUseCaseImpl(Dispatchers.Main, Dispatchers.Default, authRepository)
+        GetAccessTokenUseCaseImpl(authRepository)
 }

--- a/modules/features/auth/usecase/src/main/java/lu/aqu/projper/auth/usecase/GetAccessTokenUseCase.kt
+++ b/modules/features/auth/usecase/src/main/java/lu/aqu/projper/auth/usecase/GetAccessTokenUseCase.kt
@@ -1,5 +1,5 @@
 package lu.aqu.projper.auth.usecase
 
-import lu.aqu.core.coroutine.CoroutineUseCase
-
-interface GetAccessTokenUseCase : CoroutineUseCase<String?>
+interface GetAccessTokenUseCase {
+    fun invoke(): String?
+}

--- a/modules/features/auth/usecase/src/main/java/lu/aqu/projper/auth/usecase/impl/GetAccessTokenUseCaseImpl.kt
+++ b/modules/features/auth/usecase/src/main/java/lu/aqu/projper/auth/usecase/impl/GetAccessTokenUseCaseImpl.kt
@@ -1,17 +1,12 @@
 package lu.aqu.projper.auth.usecase.impl
 
-import kotlinx.coroutines.CoroutineDispatcher
-import lu.aqu.core.coroutine.CoroutineUseCaseAbs
 import lu.aqu.projper.auth.domain.AuthRepository
 import lu.aqu.projper.auth.usecase.GetAccessTokenUseCase
 import javax.inject.Inject
 
 class GetAccessTokenUseCaseImpl @Inject constructor(
-    mainDispatcher: CoroutineDispatcher,
-    workDispatcher: CoroutineDispatcher,
     private val authRepository: AuthRepository
-) : CoroutineUseCaseAbs<String?>(mainDispatcher, workDispatcher), GetAccessTokenUseCase {
+) : GetAccessTokenUseCase {
 
-    override suspend fun doInBackground(): String? =
-        authRepository.getAccessToken()
+    override fun invoke(): String? = authRepository.getAccessToken()
 }

--- a/modules/features/project/infra/src/main/java/lu/aqu/projper/project/infra/api/ApiModule.kt
+++ b/modules/features/project/infra/src/main/java/lu/aqu/projper/project/infra/api/ApiModule.kt
@@ -3,12 +3,12 @@ package lu.aqu.projper.project.infra.api
 import dagger.Module
 import dagger.Provides
 import lu.aqu.projper.project.infra.api.localdatasource.ProjectDataSource
+import retrofit2.Retrofit
 
 @Module
 internal class ApiModule {
 
-    // TODO change to retrofit
     @Provides
-    fun provideProjectApiClient(): ProjectApiClient =
+    fun provideProjectApiClient(retrofit: Retrofit): ProjectApiClient =
         ProjectDataSource
 }

--- a/modules/features/project/project/build.gradle
+++ b/modules/features/project/project/build.gradle
@@ -16,4 +16,6 @@ dependencies {
     implementation project(':project-usecase')
     implementation project(':project-infra')
     implementation project(':project-domain')
+
+    implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
 }

--- a/modules/features/project/project/src/main/java/lu/aqu/projper/project/ProjectModule.kt
+++ b/modules/features/project/project/src/main/java/lu/aqu/projper/project/ProjectModule.kt
@@ -1,0 +1,13 @@
+package lu.aqu.projper.project
+
+import dagger.Module
+import lu.aqu.projper.project.infra.ProjectInfraModule
+import lu.aqu.projper.project.usecase.ProjectUseCaseModule
+
+@Module(
+    includes = [
+        ProjectUseCaseModule::class,
+        ProjectInfraModule::class
+    ]
+)
+class ProjectModule

--- a/modules/features/project/project/src/main/java/lu/aqu/projper/project/details/di/DetailsComponent.kt
+++ b/modules/features/project/project/src/main/java/lu/aqu/projper/project/details/di/DetailsComponent.kt
@@ -1,14 +1,24 @@
 package lu.aqu.projper.project.details.di
 
+import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjector
 import lu.aqu.core.di.FragmentScope
 import lu.aqu.core.di.Injector
+import lu.aqu.projper.project.ProjectModule
 import lu.aqu.projper.project.details.DetailsFragment
-import lu.aqu.projper.project.usecase.ProjectUseCaseModule
+import retrofit2.Retrofit
 
-@Component(
-    modules = [ProjectUseCaseModule::class]
-)
+@Component(modules = [ProjectModule::class])
 @FragmentScope
-interface DetailsComponent : AndroidInjector<DetailsFragment>, Injector
+interface DetailsComponent : AndroidInjector<DetailsFragment>, Injector {
+
+    @Component.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun retrofit(retrofit: Retrofit): Builder
+
+        fun build(): DetailsComponent
+    }
+}

--- a/modules/features/project/project/src/main/java/lu/aqu/projper/project/overview/di/OverviewComponent.kt
+++ b/modules/features/project/project/src/main/java/lu/aqu/projper/project/overview/di/OverviewComponent.kt
@@ -1,14 +1,24 @@
 package lu.aqu.projper.project.overview.di
 
+import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjector
 import lu.aqu.core.di.FragmentScope
 import lu.aqu.core.di.Injector
+import lu.aqu.projper.project.ProjectModule
 import lu.aqu.projper.project.overview.OverviewFragment
-import lu.aqu.projper.project.usecase.ProjectUseCaseModule
+import retrofit2.Retrofit
 
-@Component(
-    modules = [ProjectUseCaseModule::class]
-)
+@Component(modules = [ProjectModule::class])
 @FragmentScope
-interface OverviewComponent : AndroidInjector<OverviewFragment>, Injector
+interface OverviewComponent : AndroidInjector<OverviewFragment>, Injector {
+
+    @Component.Builder
+    interface Builder {
+
+        @BindsInstance
+        fun retrofit(retrofit: Retrofit): Builder
+
+        fun build(): OverviewComponent
+    }
+}

--- a/modules/features/project/usecase/build.gradle
+++ b/modules/features/project/usecase/build.gradle
@@ -1,6 +1,5 @@
 apply from: '../../../../gradle/usecase.build.gradle'
 
 dependencies {
-    implementation project(':project-infra')
     implementation project(':project-domain')
 }

--- a/modules/features/project/usecase/src/main/java/lu/aqu/projper/project/usecase/ProjectUseCaseModule.kt
+++ b/modules/features/project/usecase/src/main/java/lu/aqu/projper/project/usecase/ProjectUseCaseModule.kt
@@ -4,13 +4,10 @@ import dagger.Module
 import dagger.Provides
 import kotlinx.coroutines.Dispatchers
 import lu.aqu.projper.project.domain.ProjectRepository
-import lu.aqu.projper.project.infra.ProjectInfraModule
 import lu.aqu.projper.project.usecase.impl.FindProjectByIdUseCaseImpl
 import lu.aqu.projper.project.usecase.impl.FindProjectsUseCaseImpl
 
-@Module(
-    includes = [ProjectInfraModule::class]
-)
+@Module
 class ProjectUseCaseModule {
 
     @Provides


### PR DESCRIPTION
* Prepare dependency injection of Retrofit instance including an authentication-header interceptor for logged in users
* refator dependencies: include all modules in `auth` respectively `project` module, to avoid unnecessary requirements of libraries
    * revert `auth-usecase` module back to java-library, as android dependencies have been avoided this way
* inject and bind an instance of sharedPreferences instead of a whole `AuthModule` into `LoginComponent`